### PR TITLE
Only fetch the asset's formula if we're using a LazyAssetManager

### DIFF
--- a/src/SilexAssetic/Assetic/Dumper.php
+++ b/src/SilexAssetic/Assetic/Dumper.php
@@ -98,7 +98,9 @@ class Dumper
         foreach ($am->getNames() as $name) {
             $asset   = $am->get($name);
             
-            $formula = $am->getFormula($name);
+            if ($am instanceof Assetic\LazyAssetManager){
+                $formula = $am->getFormula($name);
+            }
             
             $this->writer->writeAsset($asset);
             


### PR DESCRIPTION
This is in relation to #1. I don't want to merge it in and have the tests pass without having someone else sign off on it, as I've not used Assetic before.
