### PR TITLE
Fix to Dumper class

### DIFF
--- a/src/SilexAssetic/Assetic/Dumper.php
+++ b/src/SilexAssetic/Assetic/Dumper.php
@@ -98,7 +98,9 @@ class Dumper
         foreach ($am->getNames() as $name) {
             $asset   = $am->get($name);
             
-            $formula = $am->getFormula($name);
+            if ( $am instanceof LazyAssetManager ) {
+                $formula = $am->getFormula($name);
+            }
             
             $this->writer->writeAsset($asset);
             


### PR DESCRIPTION
The Dumper::dumpManagerAssets method was causing issues for me. It is used for dumping both lazy and 'regular' manager assets, but only LazyAssetManager instances have the getFormula() method. This commit fixes this with an instanceof check.
