### PR TITLE
Don't wipe out assetic.options on initialization.

### DIFF
--- a/src/SilexAssetic/AsseticExtension.php
+++ b/src/SilexAssetic/AsseticExtension.php
@@ -21,11 +21,7 @@ class AsseticExtension implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        // See if the options key has already been defined and
-        // if it has then use that.
-        try {
-            $app['assetic.options'];
-        } catch (\InvalidArgumentException $e) {
+        if (!isset($app['assetic.options'])) {
             $app['assetic.options'] = array();
         }
 


### PR DESCRIPTION
This breaks functionality when you try to load a yml file with assetic.options already defined, ie. Loading config values from Igorw\Silex\ConfigServiceProvider before the Assetic provider has been loaded.

I don't like checking the existence of the options key this way. If there's something better then let me know.
