### PR TITLE
fix composer failing to find repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Create a composer.json in your projects root-directory::
 
     {
         "require": {
-            "mheap/Silex-Assetic": "*"
+            "mheap/Silex-Assetic": "dev-master@dev"
         }
     }
 


### PR DESCRIPTION
When using `"*"` to specify the version, `composer` fails with 'The requested package mheap/silex-assetic could not be found in any version, there may be a typo in the package name.'.

`composer` version: `d929a0813ae473272d151d9ebb2af7ebae451e48` (from the Windows installer). Also reproduced with the latest version - `2b385cbe5825e03d58a1a531faf0c96bf3717e07`.
