### PR TITLE
Update finder dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.0",
         "kriswallsmith/assetic": "~1.0",
-        "symfony/finder": "~2.1.0"
+        "symfony/finder": ">=2.1,<2.3-dev"
     },
     "require-dev": {
         "silex/silex": "~1.0@dev",


### PR DESCRIPTION
Is there any reason, to force finder 2.1 ?
