### PR TITLE
Remove limitation for templates with '.twig' file extension

### DIFF
--- a/src/SilexAssetic/Assetic/Dumper.php
+++ b/src/SilexAssetic/Assetic/Dumper.php
@@ -72,7 +72,7 @@ class Dumper
         foreach ($twigNamespaces as $ns) {
 
             if ( count($this->loader->getPaths($ns)) > 0 ) {
-                $iterator = $finder->files()->name('/\.twig$/')->in($this->loader->getPaths($ns));
+                $iterator = $finder->files()->in($this->loader->getPaths($ns));
 
                 foreach ($iterator as $file) {
                     $resource = new TwigResource($this->loader, $file->getRelativePathname());


### PR DESCRIPTION
Makes the use of the Twig Extension work for templates with any filename, not only those which end with '.twig'.
