### PR TITLE
Avoid reevaluating namespace paths

### DIFF
--- a/src/SilexAssetic/Assetic/Dumper.php
+++ b/src/SilexAssetic/Assetic/Dumper.php
@@ -66,13 +66,12 @@ class Dumper
             throw new \LogicException('Twig environment not set');
         }
 
-        $finder   = new Finder();
         $twigNamespaces = $this->loader->getNamespaces();
 
         foreach ($twigNamespaces as $ns) {
 
             if ( count($this->loader->getPaths($ns)) > 0 ) {
-                $iterator = $finder->files()->in($this->loader->getPaths($ns));
+                $iterator = Finder::create()->files()->in($this->loader->getPaths($ns));
 
                 foreach ($iterator as $file) {
                     $resource = new TwigResource($this->loader, '@' . $ns . '/' . $file->getRelativePathname());


### PR DESCRIPTION
Previously each time this method called the finder instance the namespace paths would get appended to the iterator meaning that each time through the loop $iterator would keep growing and referencing paths from the previous loops.
