### PR TITLE
Silex 2 and Pimple 3 compatibility (another one, with the minimal changes) 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     "require": {
         "php": ">=5.3.0",
         "kriswallsmith/assetic": "~1.0",
-        "symfony/finder": "~2.1"
+        "symfony/finder": "~2.4"
     },
     "require-dev": {
-        "silex/silex": "~1.0@dev",
+        "silex/silex": "~2.0@dev",
         "twig/twig": "~1.2",
         "phpunit/phpunit": "~3.7.10"
     },

--- a/doc/assetic.md
+++ b/doc/assetic.md
@@ -59,32 +59,28 @@ $app->register(new SilexAssetic\AsseticServiceProvider());
 
 $app['assetic.path_to_web'] = __DIR__ . '/assets';
 $app['assetic.options'] = array(
-	'debug' => true,
+    'debug' => true,
 );
-$app['assetic.filter_manager'] = $app->share(
-    $app->extend('assetic.filter_manager', function($fm, $app) {
-        $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(
-            '/usr/share/yui-compressor/yui-compressor.jar'
-        ));
-        $fm->set('yui_js', new Assetic\Filter\Yui\JsCompressorFilter(
-            '/usr/share/yui-compressor/yui-compressor.jar'
-        ));
+$app->extend('assetic.filter_manager', function($fm, $app) {
+    $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(
+        '/usr/share/yui-compressor/yui-compressor.jar'
+    ));
+    $fm->set('yui_js', new Assetic\Filter\Yui\JsCompressorFilter(
+        '/usr/share/yui-compressor/yui-compressor.jar'
+    ));
 
-        return $fm;
-    })
-);
-$app['assetic.asset_manager'] = $app->share(
-    $app->extend('assetic.asset_manager', function($am, $app) {
-        $am->set('styles', new Assetic\Asset\AssetCache(
-            new Assetic\Asset\GlobAsset(
-                __DIR__ . '/resources/css/*.css',
-                array($app['assetic.filter_manager']->get('yui_css'))
-            ),
-            new Assetic\Cache\FilesystemCache(__DIR__ . '/cache/assetic')
-        ));
-        $am->get('styles')->setTargetPath('css/styles.css');
+    return $fm;
+});
+$app->extend('assetic.asset_manager', function($am, $app) {
+    $am->set('styles', new Assetic\Asset\AssetCache(
+        new Assetic\Asset\GlobAsset(
+            __DIR__ . '/resources/css/*.css',
+            array($app['assetic.filter_manager']->get('yui_css'))
+        ),
+        new Assetic\Cache\FilesystemCache(__DIR__ . '/cache/assetic')
+    ));
+    $am->get('styles')->setTargetPath('css/styles.css');
 
-        return $am;
-    })
-);
+    return $am;
+});
 ```

--- a/example/assetic.php
+++ b/example/assetic.php
@@ -13,32 +13,28 @@ $app['assetic.options'] = array(
     'formulae_cache_dir' => __DIR__ . '/assetic/cache',
     'debug'              => false
 );
-$app['assetic.filter_manager'] = $app['assetic.filter_manager'] = $app->share(
-    $app->extend('assetic.filter_manager', function($fm, $app) {
-        $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(
-            '/usr/share/yui-compressor/yui-compressor.jar'
-        ));
-        $fm->set('yui_js', new Assetic\Filter\Yui\JsCompressorFilter(
-            '/usr/share/yui-compressor/yui-compressor.jar'
-        ));
+$app->extend('assetic.filter_manager', function($fm, $app) {
+    $fm->set('yui_css', new Assetic\Filter\Yui\CssCompressorFilter(
+        '/usr/share/yui-compressor/yui-compressor.jar'
+    ));
+    $fm->set('yui_js', new Assetic\Filter\Yui\JsCompressorFilter(
+        '/usr/share/yui-compressor/yui-compressor.jar'
+    ));
 
-        return $fm;
-    })
-);
-$app['assetic.asset_manager'] = $app->share(
-    $app->extend('assetic.asset_manager', function($am, $app) {
-        $am->set('styles', new Assetic\Asset\AssetCache(
-            new Assetic\Asset\GlobAsset(
-                __DIR__ . '/assetic/resources/css/*.css',
-                array($fm->get('yui_css'))
-            ),
-            new Assetic\Cache\FilesystemCache(__DIR__ . '/assetic/cache')
-        ));
-        $am->get('styles')->setTargetPath('css/styles');
+    return $fm;
+};
+$app->extend('assetic.asset_manager', function($am, $app) {
+    $am->set('styles', new Assetic\Asset\AssetCache(
+        new Assetic\Asset\GlobAsset(
+            __DIR__ . '/assetic/resources/css/*.css',
+            array($fm->get('yui_css'))
+        ),
+        new Assetic\Cache\FilesystemCache(__DIR__ . '/assetic/cache')
+    ));
+    $am->get('styles')->setTargetPath('css/styles');
 
-        return $am;
-    })
-);
+    return $am;
+});
 
 $app->get('/', function () use ($app) {
     return 'Hello!';

--- a/tests/SilexAssetic/Tests/AsseticServiceProviderTest.php
+++ b/tests/SilexAssetic/Tests/AsseticServiceProviderTest.php
@@ -44,13 +44,12 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $app->register(new AsseticServiceProvider());
         $app['assetic.path_to_web'] = sys_get_temp_dir();
 
-        $app['assetic.filter_manager'] = $app->share(
-            $app->extend('assetic.filter_manager', function($fm, $app) {
-                $fm->set('test_filter', new \Assetic\Filter\CssMinFilter());
+        $app->extend('assetic.filter_manager', function($fm, $app) {
+            $fm->set('test_filter', new \Assetic\Filter\CssMinFilter());
 
-                return $fm;
-            })
-        );
+            return $fm;
+        });
+
 
         $app->get('/', function () use ($app) {
             return 'AsseticExtensionTest';
@@ -69,15 +68,13 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
         $app->register(new AsseticServiceProvider());
         $app['assetic.path_to_web'] = sys_get_temp_dir();
 
-        $app['assetic.asset_manager'] = $app->share(
-            $app->extend('assetic.asset_manager', function($am, $app) {
-                $asset = new \Assetic\Asset\FileAsset(__FILE__);
-                $asset->setTargetPath(md5(__FILE__));
-                $am->set('test_asset', $asset);
+        $app->extend('assetic.asset_manager', function($am, $app) {
+            $asset = new \Assetic\Asset\FileAsset(__FILE__);
+            $asset->setTargetPath(md5(__FILE__));
+            $am->set('test_asset', $asset);
 
-                return $am;
-            })
-        );
+            return $am;
+        });
 
         $app->get('/', function () {
             return 'AsseticExtensionTest';
@@ -99,9 +96,9 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app['twig'] = $app->share(function () {
+        $app['twig'] = function () {
             return new \Twig_Environment(new \Twig_Loader_String());
-        });
+        };
 
         $app->register(new AsseticServiceProvider());
         $app['assetic.path_to_web'] = sys_get_temp_dir();


### PR DESCRIPTION
Minimal changes to use Silex 2.0-dev and Pimple 3 in silex-assetic.

- the share() method is not present anymore in Pimple 3 and functions are now shared by default.
- the extend() method also auto reassign the key with the return value, so the `$app['key'] = ` assignment before is not needed anymore.
- use new silex interface for bootable service
- use a Pimple Container in the constructor of the service.

Hope it helps.